### PR TITLE
Used chunked stream buffer to improve performance

### DIFF
--- a/src/Deserializer.cs
+++ b/src/Deserializer.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.FrozenObjects
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.FrozenObjects
 {
     using System;
     using System.IO;

--- a/tests/ComplexTypes.cs
+++ b/tests/ComplexTypes.cs
@@ -1,8 +1,11 @@
-﻿using System.Collections.Generic;
-using Microsoft.Collections.Extensions;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.FrozenObjects.UnitTests
 {
+    using System.Collections.Generic;
+    using Microsoft.Collections.Extensions;
+
     public enum LongEnum : long
     {
         Min = long.MinValue,

--- a/tests/Microsoft.FrozenObjects.Tests.csproj
+++ b/tests/Microsoft.FrozenObjects.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit.assert" Version="2.4.1" />
     <PackageReference Include="xunit.core" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/tests/SupportCode/ReadOnlyDictionarySlim.cs
+++ b/tests/SupportCode/ReadOnlyDictionarySlim.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.Collections.Extensions
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Collections.Extensions
 {
     using System;
     using System.Collections;

--- a/tests/UnitTests.cs
+++ b/tests/UnitTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 namespace Microsoft.FrozenObjects.UnitTests
 {
     using System;

--- a/tools/Library.cs
+++ b/tools/Library.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.FrozenObjects.BuildTools
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.FrozenObjects.BuildTools
 {
     using System;
     using System.IO;


### PR DESCRIPTION
This change introduced a chunked memory stream that is now used by the serializer as a buffer. Relying on the OS buffer for FileStream has turned out to be too inefficient on Windows to the point it is mostly unusable for blob sizes > 100MB.

So while the default behavior has now changed to require additional memory while serializing, it is the hope that this default will make it much more usable for applications that need frozen objects which often are large object graphs.