### PR TITLE
fixing registering handle length size which is registering extra 8 by…

### DIFF
--- a/src/Deserializer.cs
+++ b/src/Deserializer.cs
@@ -47,7 +47,7 @@ namespace Microsoft.FrozenObjects
             Marshal.WriteIntPtr((IntPtr)buffer, 0 - IntPtr.Size - IntPtr.Size, (IntPtr)(length + extraSpace));
 
             // -IntPtr.Size is for segment handle
-            Marshal.WriteIntPtr((IntPtr)buffer, 0 - IntPtr.Size, InternalHelpers.RegisterFrozenSegment((IntPtr)buffer, (IntPtr)length));
+            Marshal.WriteIntPtr((IntPtr)buffer, 0 - IntPtr.Size, InternalHelpers.RegisterFrozenSegment((IntPtr)buffer, (IntPtr)(length-IntPtr.Size)));
 
             return retVal;
         }


### PR DESCRIPTION
We are investigating our app's crash dump data and dotnet team informed us of following bug. 
 
 !verifyheap
Object 0000021b7b39c960 is too large.  End of segment at 0000021B7B39C988.
Last good object: 0000021B7B39C8E8.
Object 0000021b7b1d06f8 is too large.  End of segment at 0000021B7B1D071A.
Last good object: 0000021B7B1D06B8.
[omitted]

Here are the starting of the frozen segments - 

ephemeral segment allocation context: (0x0000020BD6EAA2E0, 0x0000020BD6EAA2F8)
         segment             begin         allocated         committed    allocated size    committed size
0000021A62A09EE0  0000021B7B390018  0000021B7B39C988  0000021B7B39C988  0xc970(51568)  0xc970(51568)
0000021A96F04640  0000021B7B1D0018  0000021B7B1D071A  0000021B7B1D071A  0x702(1794)  0x702(1794)
0000021A96F03200  0000021B7B1B0018  0000021B7B1B0FF0  0000021B7B1B0FF0  0xfd8(4056)  0xfd8(4056)
0000021A96F03A70  0000021B7B190018  0000021B7B191230  0000021B7B191230  0x1218(4632)  0x1218(4632)
[omitted]

0:005> !do 0021b7b39c960
Name:        System.String
MethodTable: 00007ff9c15d69b8
EEClass:     00007ff9c15b9cb8
Tracked Type: false
Size:        48(0x30) bytes
[omitted]
0:005> ? 0021b7b39c960+30
Evaluate expression: 2317054757264 = 0000021b`7b39c990

So the segment end was reported as 8 bytes less (it’s 0000021B7B39C988 instead of 21b`7b39c990). The 2nd segment end is also 8 bytes shorter than it should be. This doesn’t affect the GC functionally but you might want to fix this just so that you can run !verifyheap without getting a ton of errors (although I had to make a change in sos in order to run !verifyheap at all because it complains about having > 1000 segments 
